### PR TITLE
feat: 주류 카드 태그 연동

### DIFF
--- a/apps/service/src/api/query/DrinkEvaluationQuery.ts
+++ b/apps/service/src/api/query/DrinkEvaluationQuery.ts
@@ -1,17 +1,26 @@
-import { useQueries } from "react-query";
+import { useQueries, useQuery } from "react-query";
+import { DrinkWithRound } from "../../components/DrinkCard";
 import { DrinkEvaluationService, DrinkService } from "../service";
 
 const DRINK_KEY = "drink";
 const DRINK_EVALUATION_KEY = "drink_evaluation";
 
-export const useGetDrinkInfoAndEvaluationById = (id: number) =>
-  useQueries([
-    {
-      queryKey: [DRINK_KEY, id],
-      queryFn: () => DrinkService.getOneDrinkInfo({ id }),
-    },
-    {
-      queryKey: [DRINK_EVALUATION_KEY, id],
-      queryFn: () => DrinkEvaluationService.getDrinksEvaluation({ id }),
-    },
-  ]);
+export const useGetDrinkInfoById = (id: number) =>
+  useQuery({
+    queryKey: [DRINK_KEY, id],
+    queryFn: () => DrinkService.getOneDrinkInfo({ id }),
+  });
+
+export const useGetDrinkEvaluationById = (id: number) =>
+  useQuery([DRINK_EVALUATION_KEY, id], () =>
+    DrinkEvaluationService.getDrinksEvaluation({ id })
+  );
+
+export const useGetDrinksEvaluationById = (drinks: DrinkWithRound[]) =>
+  useQueries(
+    drinks.map((drink) => ({
+      queryKey: [DRINK_EVALUATION_KEY, drink?.id],
+      queryFn: () =>
+        DrinkEvaluationService.getDrinksEvaluation({ id: drink?.id }),
+    }))
+  );

--- a/apps/service/src/components/DrinkCard.tsx
+++ b/apps/service/src/components/DrinkCard.tsx
@@ -27,6 +27,7 @@ interface DrinkCardProps extends React.ComponentProps<"div"> {
   isActive?: boolean;
   isShowingTag?: boolean;
   hasSearchIcon?: boolean;
+  onImageClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   onSearchIconClick?: (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void;
 }
 
@@ -38,6 +39,7 @@ function DrinkCard({
   tags,
   isShowingTag = true,
   hasSearchIcon = true,
+  onImageClick,
   onSearchIconClick,
   ...restProps
 }: DrinkCardProps) {
@@ -48,6 +50,7 @@ function DrinkCard({
         type={type}
         iconType={iconType}
         isActive={isActive}
+        onImageClick={onImageClick}
         onSearchIconClick={onSearchIconClick}
         hasSearchIcon={hasSearchIcon}
       />

--- a/apps/service/src/components/DrinkCard.tsx
+++ b/apps/service/src/components/DrinkCard.tsx
@@ -23,6 +23,7 @@ interface DrinkCardProps extends React.ComponentProps<"div"> {
   type: DrinkCardType;
   drink: Drink;
   iconType: IconName;
+  tags: string[];
   isActive?: boolean;
   isShowingTag?: boolean;
   hasSearchIcon?: boolean;
@@ -34,6 +35,7 @@ function DrinkCard({
   drink,
   iconType,
   isActive,
+  tags,
   isShowingTag = true,
   hasSearchIcon = true,
   onSearchIconClick,
@@ -68,9 +70,7 @@ function DrinkCard({
       <DrinkName display="-webkit-box" type="button1">
         {drink?.name}
       </DrinkName>
-      {isShowingTag && (
-        <Tag tags={["대낮에", "한밤에", "친구와", "연인과"]} shorten />
-      )}
+      {isShowingTag && <Tag tags={tags} shorten />}
     </Wrapper>
   );
 }

--- a/apps/service/src/components/DrinkCard.tsx
+++ b/apps/service/src/components/DrinkCard.tsx
@@ -89,7 +89,7 @@ const DescriptionWrapper = styled.div`
 const DrinkName = styled(Text)`
   margin: 8px auto;
   word-break: keep-all;
-  min-height: 44px;
+  min-height: 44.8px;
 
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/apps/service/src/components/DrinkImage.tsx
+++ b/apps/service/src/components/DrinkImage.tsx
@@ -17,6 +17,7 @@ interface DrinkImageProps {
   isActive?: boolean;
   hasSearchIcon?: boolean;
   select?: number;
+  onImageClick?: React.ComponentProps<"div">["onClick"];
   onSearchIconClick?: (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => void;
 }
 
@@ -28,10 +29,11 @@ function DrinkImage({
   isActive = false,
   select,
   hasSearchIcon = true,
+  onImageClick,
   onSearchIconClick,
 }: DrinkImageProps) {
   return (
-    <Wrapper>
+    <Wrapper onClick={onImageClick}>
       <MainImage imgSrc={imgSrc} type={type} />
       <TypeIcon name={iconType} />
       {hasSearchIcon && (

--- a/apps/service/src/components/DrinkInfoBottomSheet.tsx
+++ b/apps/service/src/components/DrinkInfoBottomSheet.tsx
@@ -25,7 +25,7 @@ function DrinkInfoBottomSheet({
   const { id, name, abv, category } = selectedDrink;
   const result = useGetDrinkInfoById(id);
 
-  if (result.isLoading) return <div>Loading...</div>;
+  if (result.isLoading) return null;
 
   const drinkData = result.data;
 

--- a/apps/service/src/components/DrinkInfoBottomSheet.tsx
+++ b/apps/service/src/components/DrinkInfoBottomSheet.tsx
@@ -1,52 +1,73 @@
 import styled from "@emotion/styled";
 import React from "react";
-import {BottomSheet, Tag, Text, theme} from "design-system";
-import {IconName} from "design-system/components/Icon";
+import { BottomSheet, Tag, Text, theme } from "design-system";
+import { IconName } from "design-system/components/Icon";
 import DrinkInfoBottomSheetHeader from "./DrinkInfoBottomSheetHeader";
 import DrinkMetaData from "./DrinkMetaData";
 import CompetitionBar from "./CompetitionBar";
-import {DrinkWithRound} from "./DrinkCard";
-import {useGetDrinkInfoAndEvaluationById} from "../api/query";
+import { DrinkWithRound } from "./DrinkCard";
+import { useGetDrinkInfoById } from "../api/query";
+import { DrinkEvaluationDto } from "../@types/api/drinkEvaluation";
 
 interface DrinkInfoBottomSheetProps {
   selectedDrink: DrinkWithRound;
+  evaluation: DrinkEvaluationDto;
   drinkCardIcon: IconName;
   onClose(): void;
 }
 
-function DrinkInfoBottomSheet({selectedDrink, drinkCardIcon, onClose}: DrinkInfoBottomSheetProps) {
-  const {id, name, abv, category} = selectedDrink;
-  const result = useGetDrinkInfoAndEvaluationById(id);
+function DrinkInfoBottomSheet({
+  selectedDrink,
+  drinkCardIcon,
+  evaluation,
+  onClose,
+}: DrinkInfoBottomSheetProps) {
+  const { id, name, abv, category } = selectedDrink;
+  const result = useGetDrinkInfoById(id);
 
-  if (result.some(r => r.isLoading)) return <div>Loading...</div>;
+  if (result.isLoading) return <div>Loading...</div>;
 
-  const drinkData = result[0].data;
-  const evaluationResult = result[1].data?.result;
+  const drinkData = result.data;
 
-  const isReviewTopicsExist = (evaluationResult?.situation.length ?? 0) > 0;
-  const isEvaluationsExist = !!evaluationResult;
+  const isReviewTopicsExist = (evaluation.result?.situation.length ?? 0) > 0;
+  const isEvaluationsExist = !!evaluation.result;
 
   return (
     <BottomSheet
       headerProps={{
-        children: (<DrinkInfoBottomSheetHeader drinkCardIcon={drinkCardIcon} onCloseClick={onClose}/>),
+        children: (
+          <DrinkInfoBottomSheetHeader
+            drinkCardIcon={drinkCardIcon}
+            onCloseClick={onClose}
+          />
+        ),
       }}
       contentProps={{
-        style: {marginBottom: 70}
+        style: { marginBottom: 70 },
       }}
     >
-      <Text style={{marginTop: 4}} type={"h1"}>{name}</Text>
-      <DrinkMetaData abv={abv} categoryName={category} origin={drinkData?.origin ?? ""}/>
+      <Text style={{ marginTop: 4 }} type={"h1"}>
+        {name}
+      </Text>
+      <DrinkMetaData
+        abv={abv}
+        categoryName={category}
+        origin={drinkData?.origin ?? ""}
+      />
       <DrinkInformation>
         <Text type={"h4"}>정보</Text>
-        <Text style={{marginTop: 16}} type={"body3"} color={theme.palette.gray100}>
+        <Text
+          style={{ marginTop: 16 }}
+          type={"body3"}
+          color={theme.palette.gray100}
+        >
           {drinkData?.description ?? ""}
         </Text>
       </DrinkInformation>
       {isReviewTopicsExist && (
         <DrinkReviewTopics>
           <Text type={"h4"}>이럴 때 마셨어요</Text>
-          <ReviewTopicTags tags={evaluationResult?.situation ?? []}/>
+          <ReviewTopicTags tags={evaluation.result?.situation ?? []} />
         </DrinkReviewTopics>
       )}
       <DrinkReviewStatistics>
@@ -55,43 +76,47 @@ function DrinkInfoBottomSheet({selectedDrink, drinkCardIcon, onClose}: DrinkInfo
           <CompetitionBarWrapper>
             <CompetitionBar
               firstItemText={"달아요"}
-              firstItemValue={evaluationResult?.isBitter.Sweet ?? 0}
+              firstItemValue={evaluation.result?.isBitter.Sweet ?? 0}
               secondItemText={"써요"}
-              secondItemValue={evaluationResult?.isBitter.Bitter ?? 0}
+              secondItemValue={evaluation.result?.isBitter.Bitter ?? 0}
             />
             <CompetitionBar
               firstItemText={"가벼워요"}
-              firstItemValue={evaluationResult?.isHeavy.Light ?? 0}
+              firstItemValue={evaluation.result?.isHeavy.Light ?? 0}
               secondItemText={"무거워요"}
-              secondItemValue={evaluationResult?.isHeavy.Heavy ?? 0}
+              secondItemValue={evaluation.result?.isHeavy.Heavy ?? 0}
             />
             <CompetitionBar
               firstItemText={"은은함"}
-              firstItemValue={evaluationResult?.isStrong.Mild ?? 0}
+              firstItemValue={evaluation.result?.isStrong.Mild ?? 0}
               secondItemText={"진한 술맛"}
-              secondItemValue={evaluationResult?.isStrong.Strong ?? 0}
+              secondItemValue={evaluation.result?.isStrong.Strong ?? 0}
             />
             <CompetitionBar
               firstItemText={"부드러운 목넘김"}
-              firstItemValue={evaluationResult?.isBurning.Smooth ?? 0}
+              firstItemValue={evaluation.result?.isBurning.Smooth ?? 0}
               secondItemText={"화끈한 목넘김"}
-              secondItemValue={evaluationResult?.isBurning.Burning ?? 0}
+              secondItemValue={evaluation.result?.isBurning.Burning ?? 0}
             />
           </CompetitionBarWrapper>
         ) : (
           <EmptyReviewWrapper>
-            <EmptyReviewImage src={'/Review IMG.png'}/>
-            <Text style={{marginTop: 12}} type={"h3"} textAlign={"center"}>
+            <EmptyReviewImage src={"/Review IMG.png"} />
+            <Text style={{ marginTop: 12 }} type={"h3"} textAlign={"center"}>
               아직 리뷰가 없어요 :(
             </Text>
-            <Text style={{marginTop: 4}} type={"body3"} color={theme.palette.gray100}>
+            <Text
+              style={{ marginTop: 4 }}
+              type={"body3"}
+              color={theme.palette.gray100}
+            >
               이 술의 첫번째 리뷰어가 되어보세요!
             </Text>
           </EmptyReviewWrapper>
         )}
       </DrinkReviewStatistics>
     </BottomSheet>
-  )
+  );
 }
 
 const DrinkInformation = styled.div`

--- a/apps/service/src/components/WinnerCard.tsx
+++ b/apps/service/src/components/WinnerCard.tsx
@@ -4,6 +4,7 @@ import DrinkCard, { Drink } from "./DrinkCard";
 
 interface WinnerCardProps extends React.ComponentProps<"div"> {
   drink: Drink;
+  tags: string[];
   handleClickSearchIcon?: (
     e: React.MouseEvent<SVGSVGElement, MouseEvent>
   ) => void;
@@ -11,6 +12,7 @@ interface WinnerCardProps extends React.ComponentProps<"div"> {
 
 function WinnerCard({
   drink,
+  tags,
   handleClickSearchIcon,
   ...restProps
 }: WinnerCardProps) {
@@ -21,6 +23,7 @@ function WinnerCard({
         type="winner"
         iconType="winner"
         drink={drink}
+        tags={tags ?? []}
         onSearchIconClick={handleClickSearchIcon}
       />
     </Wrapper>

--- a/apps/service/src/pages/category/[with].tsx
+++ b/apps/service/src/pages/category/[with].tsx
@@ -19,7 +19,7 @@ const Type = ({ withWho }: Props) => {
     useGetWorldCupInfosByCategorizingWithWho();
 
   if (isLoading || worldcups === undefined) {
-    return <div>Loading...</div>;
+    return null;
   }
   const worldCupSituations = worldcups[withWho].map((v) => ({
     situation: v.situation,

--- a/apps/service/src/pages/result/[mode]/[drinkId].tsx
+++ b/apps/service/src/pages/result/[mode]/[drinkId].tsx
@@ -17,6 +17,8 @@ import { useNavigate, useUserAgent, useWorldCup } from "../../../hooks";
 import DrinkInfoBottomSheet from "../../../components/DrinkInfoBottomSheet";
 import { DrinkWithRound } from "../../../components/DrinkCard";
 import { worldCupState as state } from "../../../store";
+import { useGetDrinkEvaluationById } from "../../../api/query";
+import { DrinkEvaluationDto } from "../../../@types/api/drinkEvaluation";
 
 const BASE_URL = `https://zuzu-web.vercel.app`;
 
@@ -41,6 +43,9 @@ const Result = ({ drinkId, mode }: Props) => {
   const [isDrinkDetailBottomSheetOpened, setIsDrinkDetailBottomSheetOpened] =
     React.useState(false);
 
+  const { data: winnerDrinkEvaluation } = useGetDrinkEvaluationById(
+    winnerDrink.id
+  );
   const shared = mode === "shared";
 
   React.useEffect(() => {
@@ -86,6 +91,7 @@ const Result = ({ drinkId, mode }: Props) => {
         <DrinkInfoBottomSheet
           drinkCardIcon="winner"
           selectedDrink={winnerDrink}
+          evaluation={winnerDrinkEvaluation as DrinkEvaluationDto}
           onClose={() => setIsDrinkDetailBottomSheetOpened(false)}
         />
       )}
@@ -101,6 +107,7 @@ const Result = ({ drinkId, mode }: Props) => {
       </Title>
       <WinnerCard
         drink={winnerDrink ?? DRINK_CARDS[3]}
+        tags={winnerDrinkEvaluation?.result?.situation as string[]}
         handleClickSearchIcon={() => setIsDrinkDetailBottomSheetOpened(true)}
       />
       <ShareButtons

--- a/apps/service/src/pages/round.tsx
+++ b/apps/service/src/pages/round.tsx
@@ -22,7 +22,7 @@ const RoundPage = () => {
   );
 
   if (isLoading || worldCupInfo === undefined) {
-    return <div>Loading...</div>;
+    return null;
   }
   const rounds = worldCupInfo.round;
 

--- a/apps/service/src/pages/worldcup.tsx
+++ b/apps/service/src/pages/worldcup.tsx
@@ -93,12 +93,17 @@ const WorldCup = () => {
               drink={drink}
               isActive={selectedDrink === drink}
               iconType={idx === 0 ? "typeA" : "typeB"}
-              onClick={() => handleDrinkCardClick(drink)}
-              tags={candidateDrinksEvaluation[idx].data?.result?.situation as string[]}
+              onImageClick={() => handleDrinkCardClick(drink)}
+              tags={
+                candidateDrinksEvaluation[idx].data?.result
+                  ?.situation as string[]
+              }
               onSearchIconClick={(e) => {
                 e.stopPropagation();
                 setDrinkToReadMore(drink);
-                setEvaluationToReadMore(candidateDrinksEvaluation[idx].data as DrinkEvaluationDto);
+                setEvaluationToReadMore(
+                  candidateDrinksEvaluation[idx].data as DrinkEvaluationDto
+                );
                 setBottomSheetOpened(true);
               }}
             />

--- a/apps/service/src/pages/worldcup.tsx
+++ b/apps/service/src/pages/worldcup.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 import { BottomButton, theme, Title } from "design-system";
 import * as React from "react";
 import { useRecoilState } from "recoil";
+import { DrinkEvaluationDto } from "../@types/api/drinkEvaluation";
+import { useGetDrinksEvaluationById } from "../api/query";
 import { Header } from "../components";
 import DrinkCard, { DrinkWithRound } from "../components/DrinkCard";
 import DrinkInfoBottomSheet from "../components/DrinkInfoBottomSheet";
@@ -14,6 +16,8 @@ const WorldCup = () => {
     React.useState<DrinkWithRound | null>(null);
   const [drinkToReadMore, setDrinkToReadMore] =
     React.useState<DrinkWithRound | null>(null);
+  const [evaluationToReadMore, setEvaluationToReadMore] =
+    React.useState<DrinkEvaluationDto | null>(null);
   const [isBottomSheetOpened, setBottomSheetOpened] = React.useState(false);
   const [worldCupState, setWorldCupState] = useRecoilState(recoilWorldCupState);
   const navigate = useNavigate();
@@ -24,6 +28,12 @@ const WorldCup = () => {
     getTitle,
   } = useWorldCup();
   const candidateDrinks = getCurrentCandidate();
+  const candidateDrinksEvaluation = useGetDrinksEvaluationById(candidateDrinks);
+  if (
+    candidateDrinksEvaluation.some((r) => r.isLoading) ||
+    candidateDrinksEvaluation.some((r) => r.data === undefined)
+  )
+    return null;
 
   const handleDrinkCardClick = (drink: DrinkWithRound) => {
     if (drink === selectedDrink) setSelectedDrink(null);
@@ -61,6 +71,7 @@ const WorldCup = () => {
       {isBottomSheetOpened && drinkToReadMore && (
         <DrinkInfoBottomSheet
           selectedDrink={drinkToReadMore}
+          evaluation={evaluationToReadMore as DrinkEvaluationDto}
           drinkCardIcon={
             candidateDrinks[0].id === drinkToReadMore.id ? "typeA" : "typeB"
           }
@@ -83,9 +94,11 @@ const WorldCup = () => {
               isActive={selectedDrink === drink}
               iconType={idx === 0 ? "typeA" : "typeB"}
               onClick={() => handleDrinkCardClick(drink)}
+              tags={candidateDrinksEvaluation[idx].data?.result?.situation as string[]}
               onSearchIconClick={(e) => {
                 e.stopPropagation();
                 setDrinkToReadMore(drink);
+                setEvaluationToReadMore(candidateDrinksEvaluation[idx].data as DrinkEvaluationDto);
                 setBottomSheetOpened(true);
               }}
             />


### PR DESCRIPTION
## 전달사항

기존에서는 BottomSheet을 열어야 `drink-evaluation` api를 호출하면서, situations 등의 정보를 받고 있었습니다 !

그런데, 월드컵에 보여질 주류 카드 태그 정보들은 BottomSheet에서만 사용되는게 아니라, DrinkCard 에서도 사용해야 하기에 `drink-evaluation` api 호출 위치를 페이지 내부에서 렌더링마다 호출하게 바꾸었습니다.

제일 좋은 방법은 drink를 받을 때 situation을 달라고 하는 게 좋을 것 같지만, 오늘 배포 시연영상이 있고, 남은 시간이 많지는 않아 위와 같은 방법을 적용했습니다.

## 작업사항

- [x] drink-evaluation api 호출을 bottomSheet에서 페이지(worldcup, result)로 바꿈
- [x] 주류 이름 길이에 따라 1줄이 더 짧아 보여서 확인한 결과 0.8px가 작아서 min-height 속성을 늘림
- [x] 로딩 컴포넌트가 없음에 따라 `Loading...` 이 잠시 나오는 것보다는 안나오는게 나을 것 같아서 로딩 중이면 null 리턴 => 혹시 다른 좋은 방법이 있을까요?
- [x] 주류 카드 이름을 클릭해도 선택되던 상황 방지 => 월드컵시 클릭 영역 이미지로만 제한
